### PR TITLE
Create script for starting docker containers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "ay2324s1-course-assessment-g23",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/start_containers.sh
+++ b/start_containers.sh
@@ -1,0 +1,3 @@
+# Bring down the services and remove all images, before building/starting.
+docker-compose down --rmi all \
+  && docker-compose --env-file .env up --build "$@"


### PR DESCRIPTION
Created a script named `start_containers.sh` to start all or just some of the docker containers.  
It'll also stop/remove/rebuild old images/containers to avoid leaving dangling images.

> **Note:** to run the `.sh` shell script, u'll need probably need to use a linux-like terminal. I'm using Git Bash on my Windows 10 to run it.

To start ALL docker containers:
```bash
bash start_containers.sh
```

To start only some of the docker containers _(eg. only api + database)_:
```bash
bash start_containers.sh api database
```