### PR TITLE
Add minor UI fixes

### DIFF
--- a/frontend/src/components/QuestionTable/QuestionReadOnlyRow.tsx
+++ b/frontend/src/components/QuestionTable/QuestionReadOnlyRow.tsx
@@ -83,6 +83,7 @@ const QuestionReadOnlyRow: React.FC<ReadOnlyRowProps> = ({
             >
                 <DialogTitle
                     style={{
+                        fontWeight: 'bold',
                         backgroundColor: '#242424',
                         color: 'white',
                         width: '700px',
@@ -115,6 +116,32 @@ const QuestionReadOnlyRow: React.FC<ReadOnlyRowProps> = ({
                             disableFocusRipple
                             disableRipple
                             size='medium'
+                            onClick={handleClose}
+                            style={{
+                                color: 'white',
+                                paddingLeft: '25px',
+                                paddingRight: '25px',
+                                marginRight: '15px',
+                                textTransform: 'none',
+                                width: '5rem',
+                                maxWidth: '700px',
+                                backgroundColor: '#303030',
+                            }}
+                            sx={{
+                                ml: 1,
+                                '&.MuiButtonBase-root:hover': {
+                                    bgcolor: 'transparent',
+                                },
+                            }}
+                        >
+                            <Typography variant='subtitle1' sx={{ fontWeight: 'bold' }}>
+                                Cancel
+                            </Typography>
+                        </Button>
+                        <Button
+                            disableFocusRipple
+                            disableRipple
+                            size='medium'
                             onClick={handleEditDescription}
                             style={{
                                 color: 'white',
@@ -124,7 +151,7 @@ const QuestionReadOnlyRow: React.FC<ReadOnlyRowProps> = ({
                                 textTransform: 'none',
                                 width: '5rem',
                                 maxWidth: '700px',
-                                backgroundColor: 'black',
+                                backgroundColor: '#238636',
                             }}
                             sx={{
                                 ml: 1,
@@ -133,7 +160,9 @@ const QuestionReadOnlyRow: React.FC<ReadOnlyRowProps> = ({
                                 },
                             }}
                         >
-                            <Typography variant='subtitle1'>Save</Typography>
+                            <Typography variant='subtitle1' sx={{ fontWeight: 'bold' }}>
+                                Save
+                            </Typography>
                         </Button>
                     </DialogActions>
                 )}

--- a/frontend/src/components/QuestionTable/QuestionReadOnlyRow.tsx
+++ b/frontend/src/components/QuestionTable/QuestionReadOnlyRow.tsx
@@ -6,7 +6,6 @@ import {
     DialogContent,
     DialogContentText,
     DialogTitle,
-    IconButton,
     TextField,
     Typography,
 } from '@mui/material'
@@ -77,25 +76,24 @@ const QuestionReadOnlyRow: React.FC<ReadOnlyRowProps> = ({
                 onClose={handleClose}
                 aria-labelledby='alert-dialog-title'
                 aria-describedby='alert-dialog-description'
+                maxWidth='md'
+                PaperProps={{
+                    sx: { borderRadius: '1rem', backgroundColor: '#242424', padding: '1rem' },
+                }}
             >
-                <DialogTitle style={{ backgroundColor: '#242424', color: 'white' }}>
+                <DialogTitle
+                    style={{
+                        backgroundColor: '#242424',
+                        color: 'white',
+                        width: '700px',
+                    }}
+                >
                     {hasActions ? 'Edit Description' : 'Description'}
                 </DialogTitle>
-                <IconButton
-                    aria-label='close'
-                    disableRipple
-                    onClick={handleClose}
-                    sx={{
-                        position: 'absolute',
-                        right: 10,
-                        top: 10,
-                        color: (theme) => theme.palette.grey[500],
-                    }}
-                ></IconButton>
-                <DialogContent style={{ backgroundColor: '#242424', width: '600px' }}>
+                <DialogContent style={{ backgroundColor: '#242424' }}>
                     {hasActions ? (
                         <TextField
-                            style={{ width: '36rem', paddingRight: '20px' }}
+                            style={{ width: '100%' }}
                             fullWidth
                             multiline
                             rows={10}
@@ -112,7 +110,7 @@ const QuestionReadOnlyRow: React.FC<ReadOnlyRowProps> = ({
                     )}
                 </DialogContent>
                 {hasActions && (
-                    <DialogActions style={{ backgroundColor: '#242424', width: '38rem' }}>
+                    <DialogActions style={{ backgroundColor: '#242424' }}>
                         <Button
                             disableFocusRipple
                             disableRipple
@@ -122,7 +120,17 @@ const QuestionReadOnlyRow: React.FC<ReadOnlyRowProps> = ({
                                 color: 'white',
                                 paddingLeft: '25px',
                                 paddingRight: '25px',
+                                marginRight: '15px',
                                 textTransform: 'none',
+                                width: '5rem',
+                                maxWidth: '700px',
+                                backgroundColor: 'black',
+                            }}
+                            sx={{
+                                ml: 1,
+                                '&.MuiButtonBase-root:hover': {
+                                    bgcolor: 'transparent',
+                                },
                             }}
                         >
                             <Typography variant='subtitle1'>Save</Typography>

--- a/frontend/src/components/QuestionTable/QuestionReadOnlyRow.tsx
+++ b/frontend/src/components/QuestionTable/QuestionReadOnlyRow.tsx
@@ -57,7 +57,7 @@ const QuestionReadOnlyRow: React.FC<ReadOnlyRowProps> = ({
                     {question.title}
                 </td>
                 <td>{question.category}</td>
-                <td>{question.complexity}</td>
+                <td className={`complexity-color-${question.complexity}`}>{question.complexity}</td>
                 {hasActions && (
                     <td>
                         <button type='button' onClick={(event) => handleEditClick(event, question)}>
@@ -92,7 +92,7 @@ const QuestionReadOnlyRow: React.FC<ReadOnlyRowProps> = ({
                         color: (theme) => theme.palette.grey[500],
                     }}
                 ></IconButton>
-                <DialogContent style={{ backgroundColor: '#242424', width: '700px' }}>
+                <DialogContent style={{ backgroundColor: '#242424', width: '600px' }}>
                     {hasActions ? (
                         <TextField
                             style={{ width: '36rem', paddingRight: '20px' }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -65,3 +65,18 @@ button:focus-visible {
         background-color: #f9f9f9;
     }
 }
+
+.complexity-color-Easy {
+    color: #00b8a2;
+    font-weight: bold;
+}
+
+.complexity-color-Medium {
+    color: #febf1d;
+    font-weight: bold;
+}
+
+.complexity-color-Hard {
+    color: #fe375f;
+    font-weight: bold;
+}


### PR DESCRIPTION
Fixed question description bug mentioned in issues #88 and #89.

New question description box for maintainers:
<img width="675" alt="Screenshot 2023-09-25 at 1 00 39 PM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g23/assets/93078202/6cdc4659-1119-4c02-b06a-3b41b568cb91">

For normal users:
<img width="685" alt="Screenshot 2023-09-25 at 1 00 17 PM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g23/assets/93078202/77dfdb59-dba8-4850-a08a-10662f02f568">

Also added slight UI improvement for question complexity (different font colors for each complexity):
<img width="785" alt="Screenshot 2023-09-25 at 12 46 06 PM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g23/assets/93078202/f838f491-7386-4a0f-a63b-5a935632879a">


