### PR TITLE
Fix fastapi malforming `ServiceErrors` responses

### DIFF
--- a/backend_services/questions_service/api/app/main.py
+++ b/backend_services/questions_service/api/app/main.py
@@ -18,24 +18,24 @@ app.add_middleware(
     expose_headers=["*"],
 )
 
-@app.post("/questions", status_code=200)
+@app.post("/questions", status_code=200, response_model=None)
 async def create_question(r: CreateQuestionRequest) -> CreateQuestionResponse | ServiceError:
     question_id = str(uuid.uuid4())
     return qc.create_question(question_id, r.title, r.description, r.category, r.complexity)
 
-@app.get("/questions/{question_id}", status_code=200)
+@app.get("/questions/{question_id}", status_code=200, response_model=None)
 async def get_question(question_id: str) -> GetQuestionResponse | ServiceError:
     return qc.get_question(question_id)
 
-@app.get("/questions_all", status_code=200)
+@app.get("/questions_all", status_code=200, response_model=None)
 async def get_all_questions() -> list[GetQuestionResponse]:
     return qc.get_all_questions()
 
 
-@app.put("/questions", status_code=200)
+@app.put("/questions", status_code=200, response_model=None)
 async def update_question_info(r: UpdateQuestionRequest) -> UpdateQuestionResponse | ServiceError:
     return qc.update_question_info(r.question_id, r.title, r.description, r.category, r.complexity)
 
-@app.delete("/questions/{question_id}", status_code=200)
+@app.delete("/questions/{question_id}", status_code=200, response_model=None)
 async def delete_question(question_id: str) -> DeleteQuestionResponse | ServiceError:
     return qc.delete_question(question_id)

--- a/backend_services/users_service/api/app/main.py
+++ b/backend_services/users_service/api/app/main.py
@@ -18,47 +18,47 @@ app.add_middleware(
     expose_headers=["*"]
 )
 
-@app.post("/users", status_code=200)
+@app.post("/users", status_code=200, response_model=None)
 async def create_user(r: CreateUserRequest) -> CreateUserResponse | ServiceError:
     user_id = str(uuid.uuid4())
     return uc.create_user(user_id, r.username, r.email, r.password)
 
-@app.get("/users/{user_id}", status_code=200)
+@app.get("/users/{user_id}", status_code=200, response_model=None)
 async def get_user(user_id: str) -> GetUserResponse:
     return uc.get_user(user_id)
 
-@app.get("/users_all", status_code=200)
+@app.get("/users_all", status_code=200, response_model=None)
 async def get_all_users() -> list[GetUserResponse]:
     return uc.get_all_users()
 
-@app.delete("/users_all", status_code=200)
+@app.delete("/users_all", status_code=200, response_model=None)
 async def delete_all_users() -> DeleteUserResponse:
     return uc.delete_all_users()
 
-@app.delete("/users/{user_id}", status_code=200)
+@app.delete("/users/{user_id}", status_code=200, response_model=None)
 async def delete_user(user_id: str) -> DeleteUserResponse | ServiceError:
     return uc.delete_user(user_id)
 
-@app.put("/users/{user_id}", status_code=200)
+@app.put("/users/{user_id}", status_code=200, response_model=None)
 async def update_user_info(user_id: str, r: UpdateUserRequest) -> UpdateUserResponse | ServiceError:
     return uc.update_user_info(user_id, r.username, r.password, r.email)
 
-@app.put("/users_role/{user_id}", status_code=200)
+@app.put("/users_role/{user_id}", status_code=200, response_model=None)
 async def update_user_role(user_id: str, r: UpdateUserRoleRequest) -> UpdateUserRoleResponse | ServiceError:
     return uc.update_user_role(user_id, r.role)
 
-@app.post("/sessions", status_code=200)
+@app.post("/sessions", status_code=200, response_model=None)
 async def user_login(r: UserLoginRequest) -> UserLoginResponse | ServiceError:
     return sc.user_login(r.username, r.password)
 
-@app.get("/sessions_all",  status_code=200)
+@app.get("/sessions_all",  status_code=200, response_model=None)
 async def get_all_sessions() -> list[GetSessionResponse]:
     return sc.get_all_sessions()
 
-@app.get("/sessions/{session_id}",  status_code=200)
+@app.get("/sessions/{session_id}",  status_code=200, response_model=None)
 async def get_session(session_id: str) -> GetSessionResponse | ServiceError:
     return sc.get_session(session_id)
 
-@app.delete("/sessions/{session_id}",  status_code=200)
+@app.delete("/sessions/{session_id}",  status_code=200, response_model=None)
 async def user_logout(session_id: str) -> UserLogoutResponse | ServiceError:
     return sc.user_logout(session_id)


### PR DESCRIPTION
Fixes #168

The problem is documented in fastapi docs:
https://fastapi.tiangolo.com/tutorial/response-model/#invalid-return-type-annotations

And the solution is to disable response model as per fastapi docs: https://fastapi.tiangolo.com/tutorial/response-model/#disable-response-model