### PR TITLE
Protect users & questions API-endpoints

### DIFF
--- a/backend_services/shared_definitions/shared_definitions/auth/fastapi_dependencies.py
+++ b/backend_services/shared_definitions/shared_definitions/auth/fastapi_dependencies.py
@@ -92,3 +92,115 @@ def decode_refresh_token_data(refresh_token: str | None = Cookie(None)) -> Token
         raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED)
 
     return token_data
+
+
+def require_maintainer_role(access_token: str | None = Cookie(None)) -> None:
+    """FastAPI dependency for requiring `"maintainer"` role to access API endpoint.
+
+    Raises `HTTPException(status_code=HTTPStatus.UNAUTHORIZED)` on:
+    - missing `access_token` cookie
+    - expired `access_token`
+    - unable to decoded `access_token`
+
+    Raises `HTTPException(status_code=HTTPStatus.FORBIDDEN)` on:
+    - `role` in `access_token` cookie is not `"maintainer"`
+
+    Args:
+        access_token (str | None, optional): `access_token` cookie. \
+            Defaults to `Cookie(None)`.
+
+    Raises:
+        HTTPException: With `status_code=HTTPStatus.UNAUTHORIZED` if \
+            `access_token` cookie is missing, expired, or unable to be decoded. \
+            With `status_code=HTTPStatus.FORBIDDEN` if `role != "maintainer"`.
+
+    Examples:
+        ```py
+        from fastapi import Depends
+
+        # Set all API-endpoints to require "maintainer" role.
+        app = FastAPI(dependencies=[Depends(require_maintainer_role)])
+
+        # Set an API-endpoint to require "maintainer" role.
+        @app.delete("/users", dependencies=[Depends(require_maintainer_role)])
+        async def delete_users():
+        ```
+    """
+    token_data = decode_access_token_data(access_token)
+
+    if token_data.role != "maintainer":
+        raise HTTPException(status_code=HTTPStatus.FORBIDDEN)
+
+
+def require_logged_in(access_token: str | None = Cookie(None)) -> None:
+    """FastAPI dependency for requiring user to be logged in to access API endpoint.
+
+    Raises `HTTPException(status_code=HTTPStatus.UNAUTHORIZED)` if `access_token` cookie is:
+    - missing
+    - expired
+    - unable to be decoded
+
+    Args:
+        access_token (str | None, optional): `access_token` cookie. \
+            Defaults to `Cookie(None)`.
+
+    Raises:
+        HTTPException: With `status_code=HTTPStatus.UNAUTHORIZED` if \
+            `access_token` cookie is missing, expired, or unable to be decoded.
+
+    Examples:
+        ```py
+        from fastapi import Depends
+
+        # Set all API-endpoints to require user to be logged in.
+        app = FastAPI(dependencies=[Depends(require_logged_in)])
+
+        # Set an API-endpoint to require user to be logged in.
+        @app.get("/users", dependencies=[Depends(require_logged_in)])
+        async def get_users():
+        ```
+    """
+    decode_access_token_data(access_token)
+
+
+def require_same_user_or_maintainer_role(user_id: str, access_token: str | None = Cookie(None)) -> None:
+    """FastAPI dependency for requiring same `user_id` as in the API's path or `"maintainer"` role
+    to access API endpoint.
+
+    API-endpoint MUST have `{user_id}` in their URL path (eg. "/users/{user_id}").
+
+    Raises `HTTPException(status_code=HTTPStatus.UNAUTHORIZED)` on:
+    - missing `access_token` cookie
+    - expired `access_token`
+    - unable to decoded `access_token`
+
+    Raises `HTTPException(status_code=HTTPStatus.FORBIDDEN)` on:
+    - (`user_id` in `access_token` cookie) is not (`user_id` in API's path.)
+    - AND (`role` in `access_token` cookie is not `"maintainer"`)
+
+    Args:
+        access_token (str | None, optional): `access_token` cookie. \
+            Defaults to `Cookie(None)`.
+
+    Raises:
+        HTTPException: With `status_code=HTTPStatus.UNAUTHORIZED` if \
+            `access_token` cookie is missing, expired, or unable to be decoded. \
+            With `status_code=HTTPStatus.FORBIDDEN` if `user_id` doesn't match.
+
+    Examples:
+        ```py
+        from fastapi import Depends
+
+        # Set all API-endpoints to require either matching `user_id` or have "maintainer" role.
+        app = FastAPI(dependencies=[Depends(require_same_user_or_maintainer_role)])
+
+        # Set an API-endpoint to require either matching `user_id` or have "maintainer" role.
+        @app.delete("/users/{user_id}", dependencies=[Depends(require_same_user_or_maintainer_role)])
+        async def delete_user(user_id: str) -> DeleteUserResponse:
+            return uc.delete_user(user_id)
+        ```
+    """
+    token_data = decode_access_token_data(access_token)
+
+    if token_data.user_id != user_id and token_data.role != "maintainer":
+        raise HTTPException(status_code=HTTPStatus.FORBIDDEN)

--- a/backend_services/users_service/api/app/main.py
+++ b/backend_services/users_service/api/app/main.py
@@ -21,6 +21,9 @@ from shared_definitions.auth.core import TokenData
 from shared_definitions.auth.fastapi_dependencies import (
     decode_access_token_data,
     decode_refresh_token_data,
+    require_logged_in,
+    require_maintainer_role,
+    require_same_user_or_maintainer_role,
 )
 
 # create app
@@ -42,39 +45,39 @@ async def create_user(r: CreateUserRequest) -> CreateUserResponse:
     return uc.create_user(user_id, r.username, r.email, r.password)
 
 
-@app.get("/user_me")
+@app.get("/user_me", dependencies=[Depends(require_logged_in)])
 async def get_current_user(
     access_token_data: TokenData = Depends(decode_access_token_data),
 ) -> GetUserResponse:
     return uc.get_current_user(access_token_data)
 
 
-@app.get("/users/{user_id}")
+@app.get("/users/{user_id}", dependencies=[Depends(require_logged_in)])
 async def get_user(user_id: str) -> GetUserResponse:
     return uc.get_user(user_id)
 
 
-@app.get("/users_all")
+@app.get("/users_all", dependencies=[Depends(require_maintainer_role)])
 async def get_all_users() -> list[GetUserResponse]:
     return uc.get_all_users()
 
 
-@app.delete("/users_all")
+@app.delete("/users_all", dependencies=[Depends(require_maintainer_role)])
 async def delete_all_users() -> DeleteUserResponse:
     return uc.delete_all_users()
 
 
-@app.delete("/users/{user_id}")
+@app.delete("/users/{user_id}", dependencies=[Depends(require_same_user_or_maintainer_role)])
 async def delete_user(user_id: str) -> DeleteUserResponse:
     return uc.delete_user(user_id)
 
 
-@app.put("/users/{user_id}")
+@app.put("/users/{user_id}", dependencies=[Depends(require_same_user_or_maintainer_role)])
 async def update_user_info(user_id: str, r: UpdateUserRequest) -> UpdateUserResponse:
     return uc.update_user_info(user_id, r.username, r.password, r.email)
 
 
-@app.put("/users_role/{user_id}")
+@app.put("/users_role/{user_id}", dependencies=[Depends(require_maintainer_role)])
 async def update_user_role(user_id: str, r: UpdateUserRoleRequest) -> UpdateUserRoleResponse:
     return uc.update_user_role(user_id, r.role)
 
@@ -89,7 +92,7 @@ async def user_logout(refresh_token: str | None = Cookie(None)) -> Response:
     return sc.user_logout(refresh_token)
 
 
-@app.get("/refresh")
+@app.get("/refresh", dependencies=[Depends(require_logged_in)])
 async def refresh_access_token(
     refresh_token_data: TokenData = Depends(decode_refresh_token_data),
 ) -> Response:


### PR DESCRIPTION
# How to protect API-endpoints

## Step 1

Install the local Python package `shared_definitions`:  
(this will give u syntax highlighting for the package later)

```bash
# If ure using Anaconda:
conda activate [CS3219_ENVIRONMENT]

cd backend_services
pip install ./shared_definitions
```

<br>

## Step 2

Insert FastAPI-dependency functions into API-endpoints to protect them:

```py
from fastapi import Depends, # ... and other FastAPI imports
from shared_definitions.auth.fastapi_dependencies import require_maintainer_role

@app.delete("/users_all", dependencies=[Depends(require_maintainer_role)])
async def delete_all_users() -> DeleteUserResponse:
    ...
```

More example of protecting API-endpoints: Commit abb423adfb1a3327ed07f5f03d9ed25f41f628c4

<br>

The available FastAPI-dependency functions are:
- `require_maintainer_role` - only maintainers can access.
- `require_logged_in` - must be logged in to access.
- `require_same_user_or_maintainer_role` - either `user_id` in path must match user's, or be a maintainer
  > _**NOTE:** MUST have `{user_id}` in API path (eg. "/users/{user_id}")_
- `decode_access_token_data` - for when API-endpoint needs to read the access token data
- `decode_refresh_token_data` - for when API-endpoint needs to read the refresh token data
