### PR TITLE
Allow running frontend in development

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3"
 services:
-  nginx:
+  api_gateway:
+    container_name: api_gateway
     image: nginx:latest
     ports:
       - "80:80"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,8 @@ services:
     build:
       context: ./frontend
     image: peerprep_frontend
+    ports:
+      - 8006:8006
     networks:
       - client-side
   base_api:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx_params_handle_websockets:/etc/nginx/nginx_params_handle_websockets:ro
     depends_on:
-      - frontend
       - users_api
       - questions_api
       - matching_api

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
     plugins: [react()],
     server: {
         host: '0.0.0.0',
-        port: 80, // Specify a fixed port to avoid random port selection
+        port: 8006, // Specify a fixed port to avoid random port selection
     },
 })

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,7 +2,7 @@ events {}
 
 http {
     upstream frontend {
-        server frontend:80;
+        server host.docker.internal:8006;
     }
 
     upstream users_service {

--- a/start_containers.sh
+++ b/start_containers.sh
@@ -18,7 +18,7 @@ if [ "$(docker volume ls | grep questions-data)" == "" ]; then
 fi
 
 # Stop any currently-running services.
-docker compose down
+docker compose down --remove-orphans
 
 # Rebuild and start the services.
 docker compose --env-file .env up --build "$@"


### PR DESCRIPTION
## Changelog
- Renamed the NGINX API-gateway's docker service/container name to `api_gateway`
- Update API-gateway to use either dockerized or Vite-dev frontend, whichever is running
- Allow running frontend seperately via `npm run dev`:
  ```bash
  # Run backend only via script.
  # (running api_gateway will run all the dependent backend services)
  bash start_containers.sh api_gateway

  # In another terminal:
  # Run frontend via Vite.
  cd frontend
  npm run dev
  ```