### PR TITLE
Standardize users & questions API error status codes

### DIFF
--- a/backend_services/questions_service/api/app/main.py
+++ b/backend_services/questions_service/api/app/main.py
@@ -1,7 +1,5 @@
-import uuid
-
 from controllers import questions_controller as qc
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, status
 from fastapi.middleware.cors import CORSMiddleware
 from shared_definitions.api_models.questions import (
     CreateQuestionRequest,
@@ -29,7 +27,11 @@ app.add_middleware(
 )
 
 
-@app.post("/questions", dependencies=[Depends(require_maintainer_role)])
+@app.post(
+    "/questions",
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_maintainer_role)],
+)
 async def create_question(r: CreateQuestionRequest) -> CreateQuestionResponse:
     return qc.create_question(r.title, r.description, r.category, r.complexity)
 

--- a/backend_services/shared_definitions/shared_definitions/api_models/questions.py
+++ b/backend_services/shared_definitions/shared_definitions/api_models/questions.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationInfo, field_validator
 
 
 class CreateQuestionRequest(BaseModel):
@@ -8,6 +8,13 @@ class CreateQuestionRequest(BaseModel):
     description: str
     category: str
     complexity: Literal["Easy", "Medium", "Hard"]
+
+    @field_validator("title", "description", "category")
+    @classmethod
+    def check_title_not_empty_or_whitespace(cls, v: str, info: ValidationInfo) -> str:
+        is_not_empty_or_whitespace = v.strip() != ""
+        assert is_not_empty_or_whitespace, f"Input cannot be empty or only whitespaces"
+        return v
 
 
 class CreateQuestionResponse(BaseModel):
@@ -18,12 +25,8 @@ class GetQuestionResponse(CreateQuestionRequest):
     question_id: str
 
 
-class UpdateQuestionRequest(BaseModel):
+class UpdateQuestionRequest(CreateQuestionRequest):
     question_id: str
-    title: str
-    description: str
-    category: str
-    complexity: str
 
 
 class UpdateQuestionResponse(BaseModel):

--- a/backend_services/users_service/api/app/controllers/users_controller.py
+++ b/backend_services/users_service/api/app/controllers/users_controller.py
@@ -108,7 +108,8 @@ def delete_user(user_id: str, access_token_data: TokenData) -> DeleteUserRespons
 
     if users_util.is_maintainer(user_id) and users_util.get_num_maintainers() == 1:
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Cannot delete last maintainer"
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot delete last maintainer",
         )
 
     db.execute_sql_write("DELETE FROM users WHERE user_id = %s", params=(user_id,))

--- a/backend_services/users_service/api/app/main.py
+++ b/backend_services/users_service/api/app/main.py
@@ -1,6 +1,6 @@
 from controllers import sessions_controller as sc
 from controllers import users_controller as uc
-from fastapi import Cookie, Depends, FastAPI
+from fastapi import Cookie, Depends, FastAPI, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
 from shared_definitions.api_models.users import (
@@ -36,7 +36,7 @@ app.add_middleware(
 )
 
 
-@app.post("/users")
+@app.post("/users", status_code=status.HTTP_201_CREATED)
 async def create_user(r: CreateUserRequest) -> CreateUserResponse:
     return uc.create_user(r.username, r.email, r.password)
 


### PR DESCRIPTION
The users & questions APIs should now follow this (unofficial) API-docs:
https://github.com/EvitanRelta/ay2324s1-course-assessment-g23/blob/temp-api-docs/API_DOCS.md