### PR TITLE
Fix judge0 server not starting

### DIFF
--- a/start_containers.sh
+++ b/start_containers.sh
@@ -17,6 +17,10 @@ if [ "$(docker volume ls | grep questions-data)" == "" ]; then
     docker volume create questions-data
 fi
 
+# Remove CR (ie. \r) characters from `judge0.conf`, as judge0 server crashes if
+# it does; and Git keeps adding them back when Git's `autocrlf` is set to "input".
+sed -i 's/\r//g' "./backend_services/code_execution_service/judge0/judge0.conf"
+
 # Stop any currently-running services.
 docker compose down --remove-orphans
 


### PR DESCRIPTION
Fixed the below bug about `\r` characters. Its caused by Judge0 not being able to handle `\r` characters from Windows CRLF newlines, and the fact that when Git's `core.autocrlf` config is set to `true`, Git automatically adds `\r` characters to file file.

![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g23/assets/35413456/d0247c72-f4dd-44e2-8621-d8d80aad0d3e)
